### PR TITLE
made Backwards case insensitive

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,7 +244,7 @@ pub struct Backwards<'s>(pub &'s str);
 
 impl IsThirteen for Backwards<'_> {
     fn thirteen(&self) -> bool {
-        self.0.to_lowercase().as_str() == "neetriht"
+        self.0.eq_ignore_ascii_case("neetriht")
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,13 +238,13 @@ impl IsThirteen for AnagramOf {
     }
 }
 
-/// `Backwards` is thirteen if it equals `"neetRiht"` (reverse spelling of "thirteen").
+/// `Backwards` is thirteen if its lowercase version equals `"neetriht"` (reverse spelling of "thirteen").
 #[derive(Debug, Clone)]
 pub struct Backwards<'s>(pub &'s str);
 
 impl IsThirteen for Backwards<'_> {
     fn thirteen(&self) -> bool {
-        self.0 == "neetRiht"
+        self.0.to_lowercase().as_str() == "neetriht"
     }
 }
 


### PR DESCRIPTION
I thought maybe `IsThirteen` for `Backwards` shouldn't be case sensitive to better match the implementation for `&str`.